### PR TITLE
Fix resize problems for jpg and bmp files if a target dimension is calculated

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,15 +8,15 @@ const Resize = require('jimp/resize');
 
 const resize = (img, opts) => {
 	if (typeof opts.width !== 'number') {
-		opts.width = img.width * (opts.height / img.height);
+		opts.width = Math.trunc(img.width * (opts.height / img.height));
 	}
 
 	if (typeof opts.height !== 'number') {
-		opts.height = img.height * (opts.width / img.width);
+		opts.height = Math.trunc(img.height * (opts.width / img.width));
 	}
 
 	return new Promise(resolve => {
-		const resize = new Resize(img.width, img.height, Math.round(opts.width), Math.round(opts.height), true, true, buf => resolve(buf));
+		const resize = new Resize(img.width, img.height, opts.width, opts.height, true, true, buf => resolve(buf));
 		resize.resize(img.data);
 	});
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resize-img",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Resize images in memory",
   "license": "MIT",
   "repository": "kevva/resize-img",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resize-img",
-  "version": "1.1.3",
+  "version": "1.1.2",
   "description": "Resize images in memory",
   "license": "MIT",
   "repository": "kevva/resize-img",

--- a/test.js
+++ b/test.js
@@ -45,13 +45,63 @@ test('resize bmp image', async t => {
 	});
 });
 
-test('resize image using only width', async t => {
+test('resize png image using only width', async t => {
 	const data = await fn(await readFile('fixture.png'), {width: 150});
 
 	t.deepEqual(imageSize(data), {
 		width: 150,
 		height: 99,
 		type: 'png'
+	});
+});
+
+test('resize jpg image using only width', async t => {
+	const data = await fn(await readFile('fixture.jpg'), {width: 150});
+
+	t.deepEqual(imageSize(data), {
+		width: 150,
+		height: 99,
+		type: 'jpg'
+	});
+});
+
+test('resize bmp image using only width', async t => {
+	const data = await fn(await readFile('fixture.bmp'), {width: 150});
+
+	t.deepEqual(imageSize(data), {
+		width: 150,
+		height: 99,
+		type: 'bmp'
+	});
+});
+
+test('resize png image using only height', async t => {
+	const data = await fn(await readFile('fixture.png'), {height: 100});
+
+	t.deepEqual(imageSize(data), {
+		width: 150,
+		height: 100,
+		type: 'png'
+	});
+});
+
+test('resize jpg image using only height', async t => {
+	const data = await fn(await readFile('fixture.jpg'), {height: 100});
+
+	t.deepEqual(imageSize(data), {
+		width: 150,
+		height: 100,
+		type: 'jpg'
+	});
+});
+
+test('resize bmp image using only height', async t => {
+	const data = await fn(await readFile('fixture.bmp'), {height: 100});
+
+	t.deepEqual(imageSize(data), {
+		width: 150,
+		height: 100,
+		type: 'bmp'
 	});
 });
 

--- a/test.js
+++ b/test.js
@@ -57,5 +57,5 @@ test('resize image using only width', async t => {
 
 test('throw when using wrong format', async t => {
 	const file = await readFile(__filename);
-	t.throws(fn(file, {width: 150}), /Image format not supported/);
+	await t.throws(fn(file, {width: 150}), /Image format not supported/);
 });


### PR DESCRIPTION
Fractional dimensions cause problems for the jpeg and bitmap encoders. I also changed the adjustment to Math.trunc instead of Math.round - using Math.round causes an 'out of range' exception from the bitmap encoder. Also, in general, I think truncation is a better choice for fractional pixels.

Thanks! This is a nice little package when resizing is the only image processing you need.