### PR TITLE
Update JIMP To 0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 	],
 	"dependencies": {
 		"file-type": "^12.3.0",
-		"jimp": "^0.8.3"
+		"jimp": "^0.10.1"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",


### PR DESCRIPTION
Updated version of [JIMP to 0.10.1](https://github.com/oliver-moran/jimp/releases). All tests continue to pass.

Among other bug fixes is an update to core-js, which is currently out-of-date and includes many issues. The package itself actually mentions this in the install logs:

> npm WARN deprecated core-js@2.6.11: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.

Based on the logs of the package (linked above), there do not appear to be any breaking changes. I have run the yarn test suite, and all tests pass. I have installed this updated package in my own project, and all images are resizing as intended.

Thank you for your consideration of this merge request, and for the excellent package. We use it for [RideTheTeacups.com](https://www.ridetheteacups.com/).